### PR TITLE
Fix: External name uses provider default org_id instead of resource-level org_id

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/crossplane/upjet/v2/pkg/config"
 )
 
@@ -8,14 +11,57 @@ import (
 // provider.
 var ExternalNameConfigs = map[string]config.ExternalName{
 	// Alertmanager configuration - uses org_id as the identifier
-	"mimir_alertmanager_config": config.IdentifierFromProvider,
+	// The Terraform provider returns the provider-level default org_id as the
+	// resource ID, but we need to use the resource-level org_id parameter instead.
+	// Users specify org_id in spec.forProvider.orgId, and we extract it from
+	// tfstate to populate the external-name annotation correctly.
+	"mimir_alertmanager_config": config.ExternalName{
+		SetIdentifierArgumentFn: config.NopSetIdentifierArgument,
+		GetExternalNameFn: func(tfstate map[string]any) (string, error) {
+			// Extract from org_id field instead of id, because the Terraform provider
+			// incorrectly returns the provider-level default org_id in the id field
+			if orgID, ok := tfstate["org_id"].(string); ok && orgID != "" {
+				return orgID, nil
+			}
+			// Fallback to id if org_id is not present in state
+			if id, ok := tfstate["id"].(string); ok && id != "" {
+				return id, nil
+			}
+			return "", fmt.Errorf("org_id and id are both empty in tfstate")
+		},
+		GetIDFn: func(_ context.Context, externalName string, _ map[string]any, _ map[string]any) (string, error) {
+			// The external name is the org_id, which is also used as the Terraform ID
+			return externalName, nil
+		},
+	},
 
 	// Rule groups - use a composite identifier: namespace/name
 	"mimir_rule_group_alerting":  config.TemplatedStringAsIdentifier("name", "{{ .parameters.namespace }}/{{ .external_name }}"),
 	"mimir_rule_group_recording": config.TemplatedStringAsIdentifier("name", "{{ .parameters.namespace }}/{{ .external_name }}"),
 
 	// Rules resource - manages multiple rule groups from a file
-	"mimir_rules": config.IdentifierFromProvider,
+	// Same issue as alertmanager config - uses org_id as the identifier
+	// Users specify org_id in spec.forProvider.orgId, and we extract it from
+	// tfstate to populate the external-name annotation correctly.
+	"mimir_rules": config.ExternalName{
+		SetIdentifierArgumentFn: config.NopSetIdentifierArgument,
+		GetExternalNameFn: func(tfstate map[string]any) (string, error) {
+			// Extract from org_id field instead of id, because the Terraform provider
+			// incorrectly returns the provider-level default org_id in the id field
+			if orgID, ok := tfstate["org_id"].(string); ok && orgID != "" {
+				return orgID, nil
+			}
+			// Fallback to id if org_id is not present in state
+			if id, ok := tfstate["id"].(string); ok && id != "" {
+				return id, nil
+			}
+			return "", fmt.Errorf("org_id and id are both empty in tfstate")
+		},
+		GetIDFn: func(_ context.Context, externalName string, _ map[string]any, _ map[string]any) (string, error) {
+			// The external name is the org_id, which is also used as the Terraform ID
+			return externalName, nil
+		},
+	},
 }
 
 // ExternalNameConfigurations applies all external name configs listed in the


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1 


### How has this code been tested

- Two resources of the type `config.alertmanager.mimir.crossplane.io` with diffrent orgIDs have been created and they show the correct external name.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
